### PR TITLE
Update 1-programming_terminology.md

### DIFF
--- a/data/part-2/1-programming_terminology.md
+++ b/data/part-2/1-programming_terminology.md
@@ -278,7 +278,7 @@ Daily wages: 120.0 euros
 
 </sample-output>
 
-The issue must then lie within the condition of the `if` statement. As in so many situations in programming, the case of letters matters also in comparisons. Notice how the "sunday" in the Boolean expression has not been capitalized, but in the input it was. Let's fix this (in both the `print` command and the `if` statement):
+The issue must then lie within the condition of the `if` statement. As in so many situations in programming, the case of letters matters also in comparisons. Notice how the "sunday" in the Boolean expression has been capitalized, but in the input it was not. Let's fix this (in both the `print` command and the `if` statement):
 
 ```python
 # ...


### PR DESCRIPTION
In Part 2 of the course, in the "Debugging" section, there was a typo that I have attempted to correct. The sentence "Notice how the "sunday" in the Boolean expression has not been capitalized, but in the input it was." Should be written as the exact opposite, in this situation. The issue with the code is that the user is attempting to input the day without capitalization, but this sentence refers to it being the Boolean expression itself that wasn't capitalized.