### PR TITLE
fix grammar mistake in part-2-2

### DIFF
--- a/data/part-2/2-else-elif.md
+++ b/data/part-2/2-else-elif.md
@@ -28,7 +28,7 @@ if number >= 0:
 
 This looks a bit clumsy and repetitive. We only ever want to execute one of the `if` blocks, because the input will always be either below zero, or zero or above. That is, either `number < 0` or `number >= 0` is true, but never both at the same time. So, the first conditional statement actually contains all we need here. If it is true, the number is negative. If it is false, the number equals zero or is positive.
 
-Instead of creating a whole another conditional statement, as in the example above, it is possible to create another branch of the same conditional statement to cover all cases _where the condition was false_. This is called the `else` statement.
+Instead of creating a whole other conditional statement, as in the example above, it is possible to create another branch of the same conditional statement to cover all cases _where the condition was false_. This is called the `else` statement.
 
 The previous example rewritten:
 
@@ -121,7 +121,7 @@ You are of age!
 
 Often there are more than two options the program should account for. For example, the result of a football match could go three ways: home wins, away wins, or there is a tie.
 
-A conditional statement can be added to with an `elif` branch. It is short for the words "else if", which means the branch will contain an alternative to the original condition. Importantly, an `elif` statement is executed only if none of the preceding branches is executed.  
+A conditional statement can be added to with an `elif` branch. It is short for the words "else if", which means the branch will contain an alternative to the original condition. Importantly, an `elif` statement is executed only if none of the preceding branches is executed.
 
 <img src="2_2_2.png">
 


### PR DESCRIPTION
I fixed a grammatical mistake in part 2, section 2 else-elif. Additionally, I removed extra whitespace.

The phrase corrected was "Instead of creating a whole another conditional statement". The correction could have changed "a whole another" to "a whole nother" which, although considered informal, is grammatically correct. I opted for the more commonly accepted "a whole other". Regardless, "a whole another" is incorrect.